### PR TITLE
Fix: testing issues

### DIFF
--- a/dispatcher/concurrency_test.go
+++ b/dispatcher/concurrency_test.go
@@ -12,7 +12,8 @@ import (
 )
 
 func TestConcurrentSubscribeUnsubscribe(t *testing.T) {
-	mux = router.NewMux()
+	setTestMux(router.NewMux())
+	t.Cleanup(func() { setTestMux(nil) })
 
 	var wg sync.WaitGroup
 	numGoroutines := 100
@@ -37,7 +38,8 @@ func TestConcurrentSubscribeUnsubscribe(t *testing.T) {
 }
 
 func TestConcurrentDispatch(t *testing.T) {
-	mux = router.NewMux()
+	setTestMux(router.NewMux())
+	t.Cleanup(func() { setTestMux(nil) })
 
 	var counter atomic.Int32
 	numHandlers := 10
@@ -76,7 +78,8 @@ func TestConcurrentDispatch(t *testing.T) {
 }
 
 func TestConcurrentSubscribeDispatch(t *testing.T) {
-	mux = router.NewMux()
+	setTestMux(router.NewMux())
+	t.Cleanup(func() { setTestMux(nil) })
 
 	var counter atomic.Int32
 	var wg sync.WaitGroup
@@ -112,7 +115,8 @@ func TestConcurrentSubscribeDispatch(t *testing.T) {
 }
 
 func TestRaceSubscribeUnsubscribe(t *testing.T) {
-	mux = router.NewMux()
+	setTestMux(router.NewMux())
+	t.Cleanup(func() { setTestMux(nil) })
 
 	done := make(chan struct{})
 
@@ -151,7 +155,8 @@ func TestRaceSubscribeUnsubscribe(t *testing.T) {
 }
 
 func TestHandlerPanic(t *testing.T) {
-	mux = router.NewMux()
+	setTestMux(router.NewMux())
+	t.Cleanup(func() { setTestMux(nil) })
 
 	panicMsg := "intentional panic"
 

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -3,6 +3,7 @@ package dispatcher
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/goliatone/go-command"
 	"github.com/goliatone/go-command/router"
@@ -19,10 +20,13 @@ var ExitOnErr = false
 var (
 	defaultMux = router.NewMux()
 	testMux    *router.Mux // Only set during tests for isolation
+	testMuxMu  sync.RWMutex
 )
 
 // getMux returns the active mux (test override or default)
 func getMux() *router.Mux {
+	testMuxMu.RLock()
+	defer testMuxMu.RUnlock()
 	if testMux != nil {
 		return testMux
 	}
@@ -31,6 +35,8 @@ func getMux() *router.Mux {
 
 // setTestMux overrides the mux for testing (package-private, test-only)
 func setTestMux(m *router.Mux) {
+	testMuxMu.Lock()
+	defer testMuxMu.Unlock()
 	testMux = m
 }
 

--- a/dispatcher/dispatcher_test.go
+++ b/dispatcher/dispatcher_test.go
@@ -117,7 +117,8 @@ func (h *GetUserHandler) Query(ctx context.Context, event GetUserMessage) (*User
 }
 
 func TestCommandDispatcher(t *testing.T) {
-	mux = router.NewMux()
+	setTestMux(router.NewMux())
+	t.Cleanup(func() { setTestMux(nil) })
 
 	t.Run("successful command execution", func(t *testing.T) {
 		db := newMockDB()
@@ -217,7 +218,8 @@ func TestCommandDispatcher(t *testing.T) {
 }
 
 func TestQueryDispatcher(t *testing.T) {
-	mux = router.NewMux()
+	setTestMux(router.NewMux())
+	t.Cleanup(func() { setTestMux(nil) })
 
 	t.Run("successful query execution", func(t *testing.T) {
 		db := newMockDB()
@@ -323,7 +325,8 @@ func TestQueryDispatcher(t *testing.T) {
 // }
 
 func TestHTTPIntegration(t *testing.T) {
-	mux = router.NewMux()
+	setTestMux(router.NewMux())
+	t.Cleanup(func() { setTestMux(nil) })
 
 	db := newMockDB()
 
@@ -660,7 +663,8 @@ func TestMessageValidation(t *testing.T) {
 }
 
 func TestDispatchWithPointers(t *testing.T) {
-	mux = router.NewMux()
+	setTestMux(router.NewMux())
+	t.Cleanup(func() { setTestMux(nil) })
 
 	commandHandler := command.CommandFunc[*TestPointerMessage](func(ctx context.Context, msg *TestPointerMessage) error {
 		msg.Value = "handled"
@@ -689,7 +693,8 @@ func TestDispatchWithPointers(t *testing.T) {
 }
 
 func TestQueryWithPointers(t *testing.T) {
-	mux = router.NewMux()
+	setTestMux(router.NewMux())
+	t.Cleanup(func() { setTestMux(nil) })
 
 	queryHandler := command.QueryFunc[*TestPointerMessage, TestResponse](func(ctx context.Context, msg *TestPointerMessage) (TestResponse, error) {
 		msg.Value = "queried"

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23.4
 
 require (
 	github.com/alecthomas/kong v1.11.0
-	github.com/goliatone/go-errors v0.4.0
+	github.com/goliatone/go-errors v0.9.0
 	github.com/goliatone/go-generators v0.16.1
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-ozzo/ozzo-validation/v4 v4.3.0 h1:byhDUpfEwjsVQb1vBunvIjh2BHQ9ead57VkAEY4V+Es=
 github.com/go-ozzo/ozzo-validation/v4 v4.3.0/go.mod h1:2NKgrcHl3z6cJs+3Oo940FPRiTzuqKbvfrL2RxCj6Ew=
-github.com/goliatone/go-errors v0.4.0 h1:nspNImzuaIIv7E/8bgMuKntkC3gf3ClP9mzdtFOf404=
-github.com/goliatone/go-errors v0.4.0/go.mod h1:FiZEC2z5a8SBdRyljC9wFt+IzqZDfrst2dPoqWARbr4=
+github.com/goliatone/go-errors v0.9.0 h1:Jvx5aV+QgSx5ZK4zagOW5YyVCUcqEYZNVZU4V1oqUDQ=
+github.com/goliatone/go-errors v0.9.0/go.mod h1:FiZEC2z5a8SBdRyljC9wFt+IzqZDfrst2dPoqWARbr4=
 github.com/goliatone/go-generators v0.16.1 h1:zNzpGyG/3Nkq4NlyC6RLuKAHhSi+cBhDvRgdCKQ+yCE=
 github.com/goliatone/go-generators v0.16.1/go.mod h1:4NC8CE0pGDpq2uOeteXC73rsoPKvqUjsXySedxlgaO8=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=


### PR DESCRIPTION
This PR fixes dispatcher tests so they can be run with the `-race` flag. 
- fix: refactor disptcher.go to expose mux facility for parallel tests
- chore: update to go-errors